### PR TITLE
Try to use centos-stream image instead bootc

### DIFF
--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -71,8 +71,6 @@ jobs:
     - name: Setup tmate session
       if: ${{ failure() && steps.image.conclusion == 'failure' }}
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
       with:
         limit-access-to-actor: true
-        timeout-minutes: 15
-
-

--- a/.github/workflows/build_images.yaml
+++ b/.github/workflows/build_images.yaml
@@ -65,9 +65,11 @@ jobs:
         ./build-images.sh
         popd
     - name: build microshift image and push
-      id: image
-      run: |
-        ./create-microshift-image.sh
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        command: ./create-microshift-image.sh
     - name: Setup tmate session
       if: ${{ failure() && steps.image.conclusion == 'failure' }}
       uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/build_images_amd64.yaml
+++ b/.github/workflows/build_images_amd64.yaml
@@ -59,8 +59,6 @@ jobs:
     - name: Setup tmate session
       if: ${{ failure() && steps.image.conclusion == 'failure' }}
       uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
       with:
         limit-access-to-actor: true
-        timeout-minutes: 15
-
-

--- a/.github/workflows/build_images_amd64.yaml
+++ b/.github/workflows/build_images_amd64.yaml
@@ -53,9 +53,11 @@ jobs:
         password: ${{ env.PASSWORD }}
         registry: "quay.io"
     - name: build microshift image and push
-      id: image
-      run: |
-        ./create-microshift-image.sh
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 45
+        max_attempts: 3
+        command: ./create-microshift-image.sh
     - name: Setup tmate session
       if: ${{ failure() && steps.image.conclusion == 'failure' }}
       uses: mxschmitt/action-tmate@v3

--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -42,7 +42,10 @@ pushd microshift
 
 echo "Embed storage.conf and dns.conf to $CONTAINERFILE"
 cp ../storage.conf ../00-dns.yaml .
+sed -i '/^FROM quay.io\/centos-bootc\/centos-bootc:stream9[[:space:]]*$/s|FROM quay.io/centos-bootc/centos-bootc:stream9|FROM quay.io/centos/centos:stream9|' $CONTAINERFILE
+sed -i 's|centos-release-nfv-openvswitch|centos-release-nfv-openvswitch hostname|' $CONTAINERFILE
 sed -i '$a COPY storage.conf /etc/containers/storage.conf\nCOPY 00-dns.yaml /etc/microshift/config.d/00-dns.yaml' $CONTAINERFILE
+sed -i '$a STOPSIGNAL SIGRTMIN+3\nCMD ["/sbin/init"]' $CONTAINERFILE
 
 # Build the image
 sudo podman build \

--- a/create-microshift-image.sh
+++ b/create-microshift-image.sh
@@ -2,6 +2,16 @@
 
 set -exuo pipefail
 
+
+# Function to remove the directory on exit
+cleanup() {
+    echo "Cleaning up: microshift"
+    rm -rf microshift
+}
+
+# Trap EXIT and INT signals to ensure cleanup
+trap cleanup EXIT INT
+
 # Detect the system architecture
 ARCH=$(uname -m)
 
@@ -61,5 +71,3 @@ sudo podman build \
 echo "Pushing image: $IMAGE_ARCH_TAG"
 sudo podman push "$IMAGE_ARCH_TAG"
 popd
-
-rm -fr microshift


### PR DESCRIPTION
Since our goal is to run these images in podman/docker not consuming for any VM so better to use normal images instead bootc which will reduce overall size.